### PR TITLE
CU-1wnyaz2 - Change the SOLR datatype of the URL fields

### DIFF
--- a/src/main/java/ca/gc/csps/regkg/RdfGatheringAgent.java
+++ b/src/main/java/ca/gc/csps/regkg/RdfGatheringAgent.java
@@ -82,8 +82,8 @@ public class RdfGatheringAgent {
     private static final String TEXT_FIELD_FRENCH = "text_fr_txt";
     private static final String TITLE_FIELD_ENGLISH = "title_en_txt";
     private static final String TITLE_FIELD_FRENCH = "title_fr_txt";
-    private static final String LINK_FIELD_ENGLISH = "url_en_str";
-    private static final String LINK_FIELD_FRENCH = "url_fr_str";
+    private static final String LINK_FIELD_ENGLISH = "url_en_s";
+    private static final String LINK_FIELD_FRENCH = "url_fr_s";
 
     private static final Charset UTF8 = StandardCharsets.UTF_8;
 


### PR DESCRIPTION
First PR of two -- this one covers the changes to the SOLR scheme so that URLs will be available to the front-end. The subsequent PR should branch after #27 gets merged to keep the merge workload down.