### PR TITLE
Reset pagination on search

### DIFF
--- a/front-end/src/components/search/QueryBox.js
+++ b/front-end/src/components/search/QueryBox.js
@@ -33,11 +33,15 @@ const QueryBox = (props) => {
   const [errorMessage, setErrorMessage] = useState("app.query.errorGeneric");
 
   // String containing what the user has put in the search box
+  const [userSearchValue, setUserSearchValue] = useState("");
+
+  // String containing what to send to the API (updated on key or button press)
   const [searchQuery, setSearchQuery] = useState("");
+
 
   // Clear the Search Query and Search Results when the language context is updated.
   useEffect(() => {
-    setSearchQuery("");
+    setUserSearchValue("");
   }, [props.language]);
 
   const submitQuery = async() => {
@@ -96,15 +100,15 @@ const QueryBox = (props) => {
   }
 
   const updateQuery = (e) => {
-    setSearchQuery(e.target.value);
+    setUserSearchValue(e.target.value);
   }
 
   // Used to skip the first render
-  const isInitialMount = useRef(true);
+  const skipOffsetQuery = useRef(true);
   // Submit a new query whenever pageOffset updated by pagination
   useEffect(() => {
-    if (isInitialMount.current) {
-       isInitialMount.current = false;
+    if (skipOffsetQuery.current) {
+       skipOffsetQuery.current = false;
     } else {
         submitQuery();
     }
@@ -113,15 +117,26 @@ const QueryBox = (props) => {
   // For keyboard navigation
   const handleKeyPress = (event) => {
     if (event.key === "Enter") {
-      submitQuery();
+      processQueryForSubmit();
     }
   }
+
+  //
+  const processQueryForSubmit = () => {
+    props.setPageOffset(0);
+    setSearchQuery(userSearchValue);
+    // Updateing SearchQuery will trigger useEffect(() => {submitQuery()}, [searchQuery])
+  }
+
+  // Used to skip the first render
+  const isInitialMountQuery = useRef(true);
+  useEffect(() => {isInitialMountQuery.current ? isInitialMountQuery.current = false : submitQuery()}, [searchQuery])
 
   return(
     <>
       <InputGroup size="lg">
-        <FormControl aria-label={ariaTranslations.searchBox} aria-describedby="inputGroup-sizing-lg" onChange={updateQuery} value={searchQuery} onKeyPress={handleKeyPress}/>
-        <Button aria-label={ariaTranslations.submitButton} variant="primary" id="search-button" onClick={submitQuery}>
+        <FormControl aria-label={ariaTranslations.searchBox} aria-describedby="inputGroup-sizing-lg" onChange={updateQuery} value={userSearchValue} onKeyPress={handleKeyPress}/>
+        <Button aria-label={ariaTranslations.submitButton} variant="primary" id="search-button" onClick={processQueryForSubmit}>
           <FormattedMessage id = "app.search.mainButton" />
         </Button>
       </InputGroup>

--- a/front-end/src/components/search/QueryBox.js
+++ b/front-end/src/components/search/QueryBox.js
@@ -32,18 +32,26 @@ const QueryBox = (props) => {
   const [show, setShow] = useState(false);
   const [errorMessage, setErrorMessage] = useState("app.query.errorGeneric");
 
+  // String containing what the user has put in the search box
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Clear the Search Query and Search Results when the language context is updated.
+  useEffect(() => {
+    setSearchQuery("");
+  }, [props.language]);
+
   const submitQuery = async() => {
     /* Single search term: https://example.com/search?df=text_en_txt&q=fish */
     const API_PREFIX = (process.env.REACT_APP_API_PREFIX ? process.env.REACT_APP_API_PREFIX : "");
     const solrPath = "/search?"
     const langTerms = `text_${props.language}_txt`;
-    const searchTerms = `q=${props.searchQuery}`;
+    const searchTerms = `q=${searchQuery}`;
     const requestURL = API_PREFIX + solrPath;
 
     setShow(false);
 
     fetch(requestURL + new URLSearchParams({
-        q:props.searchQuery,
+        q:searchQuery,
         df:`text_${props.language}_txt`,
         start:props.pageOffset,
         'q.op': "AND"
@@ -88,7 +96,7 @@ const QueryBox = (props) => {
   }
 
   const updateQuery = (e) => {
-    props.setSearchQuery(e.target.value);
+    setSearchQuery(e.target.value);
   }
 
   // Used to skip the first render
@@ -112,7 +120,7 @@ const QueryBox = (props) => {
   return(
     <>
       <InputGroup size="lg">
-        <FormControl aria-label={ariaTranslations.searchBox} aria-describedby="inputGroup-sizing-lg" onChange={updateQuery} value={props.searchQuery} onKeyPress={handleKeyPress}/>
+        <FormControl aria-label={ariaTranslations.searchBox} aria-describedby="inputGroup-sizing-lg" onChange={updateQuery} value={searchQuery} onKeyPress={handleKeyPress}/>
         <Button aria-label={ariaTranslations.submitButton} variant="primary" id="search-button" onClick={submitQuery}>
           <FormattedMessage id = "app.search.mainButton" />
         </Button>

--- a/front-end/src/pages/Search.js
+++ b/front-end/src/pages/Search.js
@@ -23,9 +23,6 @@ const Search = () => {
   const langContext = useContext(Context);
   const currentLang = langContext.locale;
 
-  // String containing what the user has put in the search box
-  const [searchQuery, setSearchQuery] = useState("");
-
   // Array of object from the search API, no extra data
   const [searchResults, setsearchResults] = useState("");
 
@@ -38,7 +35,6 @@ const Search = () => {
 
   // Clear the Search Query and Search Results when the language context is updated.
   useEffect(() => {
-    setSearchQuery("");
     setsearchResults("");
     setSparqlData("");
     setPageOffset(0);
@@ -106,7 +102,7 @@ const Search = () => {
           <p tabIndex="0">{contentTranslations.introduction}</p>
 
           {/*Search Box*/}
-          <QueryBox language={currentLang} searchQuery={searchQuery} setSearchQuery={setSearchQuery} searchResults={searchResults} setsearchResults={setsearchResults} pageOffset={pageOffset}/>
+          <QueryBox language={currentLang} searchResults={searchResults} setsearchResults={setsearchResults} pageOffset={pageOffset}/>
 
         {/*Reference Guide*/}
           <p></p> 

--- a/front-end/src/pages/Search.js
+++ b/front-end/src/pages/Search.js
@@ -102,7 +102,7 @@ const Search = () => {
           <p tabIndex="0">{contentTranslations.introduction}</p>
 
           {/*Search Box*/}
-          <QueryBox language={currentLang} searchResults={searchResults} setsearchResults={setsearchResults} pageOffset={pageOffset}/>
+          <QueryBox language={currentLang} searchResults={searchResults} setsearchResults={setsearchResults} pageOffset={pageOffset} setPageOffset={setPageOffset}/>
 
         {/*Reference Guide*/}
           <p></p> 


### PR DESCRIPTION
To accomplish this the search query was moved out of Search.JS and into QueryBox.JS.

useEffect is watching for changes to the searchQuery and resetting the pagination before sending the request to the API